### PR TITLE
Fix: sustainer errors in AutoPlant and Autocrane

### DIFF
--- a/1.3/Source/VFEM/Buildings/Building_AutoPlant.cs
+++ b/1.3/Source/VFEM/Buildings/Building_AutoPlant.cs
@@ -88,7 +88,7 @@ namespace VFE.Mechanoids.Buildings
             {
                 if (running)
                 {
-                    if (sustainer != null)
+                    if (sustainer != null && !sustainer.Ended)
                         sustainer.Maintain();
                     else
                         TryStartSustainer();
@@ -119,13 +119,25 @@ namespace VFE.Mechanoids.Buildings
                 }
                 else if (offset > 0)
                 {
-                    sustainer?.Maintain();
+                    if (sustainer != null && !sustainer.Ended)
+                        sustainer.Maintain();
+                    else
+                        TryStartSustainer(); // Necessary for startups where the machine runs in reverse
+
                     offset -= speedPerTick;
                     if (offset < 0)
                         offset = 0;
                 }
                 else
+                {
                     powerComp.powerOutputInt = -powerComp.Props.basePowerConsumption;
+                    sustainer.End();
+                }
+                    
+            }
+            else if (sustainer != null && !sustainer.Ended)
+            {
+                sustainer.End();
             }
         }
 

--- a/1.3/Source/VFEM/Buildings/Building_AutoPlant.cs
+++ b/1.3/Source/VFEM/Buildings/Building_AutoPlant.cs
@@ -74,7 +74,7 @@ namespace VFE.Mechanoids.Buildings
                 initiate.defaultDesc = "VFEMechStartMachineDesc".Translate();
                 initiate.icon = ContentFinder<Texture2D>.Get("UI/MachineryOn");
             }
-            initiate.toggleAction = delegate { running = !running;  if (running) { StartSustainer(); } };
+            initiate.toggleAction = delegate { running = !running;  if (running) { TryStartSustainer(); } };
             initiate.isActive = ()=>running;
             gizmos.Add(initiate);
 
@@ -88,11 +88,11 @@ namespace VFE.Mechanoids.Buildings
             {
                 if (running)
                 {
-                    if (sustainer is null)
-                    {
-                        StartSustainer();
-                    }
-                    sustainer.Maintain();
+                    if (sustainer != null)
+                        sustainer.Maintain();
+                    else
+                        TryStartSustainer();
+
                     powerComp.powerOutputInt = -1900;
                     bool shouldCheck = false;
                     if (offset == 0)
@@ -119,7 +119,7 @@ namespace VFE.Mechanoids.Buildings
                 }
                 else if (offset > 0)
                 {
-                    sustainer.Maintain();
+                    sustainer?.Maintain();
                     offset -= speedPerTick;
                     if (offset < 0)
                         offset = 0;
@@ -219,12 +219,13 @@ namespace VFE.Mechanoids.Buildings
             Scribe_Values.Look<float>(ref offset, "offset");
         }
 
-        void StartSustainer()
+        bool TryStartSustainer()
         {
             if (sustainer != null)
                 sustainer.End();
             SoundInfo soundInfo = SoundInfo.InMap(this);
             sustainer = SoundDef.Named("GeothermalPlant_Ambience").TrySpawnSustainer(soundInfo);
+            return sustainer != null;
         }
 
         public override void SpawnSetup(Map map, bool respawningAfterLoad)

--- a/1.3/Source/VFEM/Buildings/Building_AutoPlant.cs
+++ b/1.3/Source/VFEM/Buildings/Building_AutoPlant.cs
@@ -131,8 +131,9 @@ namespace VFE.Mechanoids.Buildings
                 else
                 {
                     powerComp.powerOutputInt = -powerComp.Props.basePowerConsumption;
+                    if (sustainer != null && !sustainer.Ended)
+                        sustainer.End();
                 }
-                    
             }
             else if (sustainer != null && !sustainer.Ended)
             {

--- a/1.3/Source/VFEM/Buildings/Building_AutoPlant.cs
+++ b/1.3/Source/VFEM/Buildings/Building_AutoPlant.cs
@@ -131,7 +131,6 @@ namespace VFE.Mechanoids.Buildings
                 else
                 {
                     powerComp.powerOutputInt = -powerComp.Props.basePowerConsumption;
-                    sustainer.End();
                 }
                     
             }

--- a/1.3/Source/VFEM/Buildings/Building_Autocrane.cs
+++ b/1.3/Source/VFEM/Buildings/Building_Autocrane.cs
@@ -269,7 +269,7 @@ namespace VFEMech
                     curCellTarget = IntVec3.Invalid;
 
                     StartMovingTo(curBuildingTarget);
-                    constructionEffecter.SetEffecterDef(curBuildingTarget.def.repairEffect);
+                    repairEffecter.SetEffecterDef(curBuildingTarget.def.repairEffect);
                     compPower.powerOutputInt = -3000;
                     return;
                 }

--- a/1.3/Source/VFEM/Buildings/Building_Autocrane.cs
+++ b/1.3/Source/VFEM/Buildings/Building_Autocrane.cs
@@ -1,14 +1,8 @@
-﻿using Mono.Unix.Native;
-using RimWorld;
-using System;
+﻿using RimWorld;
 using System.Collections.Generic;
-using System.IO.Ports;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.VFX;
 using Verse;
-using Verse.AI;
-using Verse.AI.Group;
 using Verse.Sound;
 
 namespace VFEMech


### PR DESCRIPTION
A proposal for fixing startup errors with AutoPlant (only maintain if the sustainer was successfully spawned) and Autocrane (do not attempt to sustain ended sounds).